### PR TITLE
only scan valid zip codes

### DIFF
--- a/scraper/scraper.py
+++ b/scraper/scraper.py
@@ -4,14 +4,12 @@ import os
 import random
 import time
 
-import pandas as pd
-import zipcodes
-
 from selenium import webdriver
 from selenium.webdriver.common.keys import Keys
 from selenium.webdriver.chrome.options import DesiredCapabilities
 from selenium.webdriver.common.proxy import Proxy, ProxyType
 from selenium.webdriver.common.by import By
+import zipcodes
 
 # maeve andersen
 # 27 august 2023

--- a/scraper/scraper.py
+++ b/scraper/scraper.py
@@ -1,14 +1,17 @@
 import csv
+import json
+import os
+import random
 import time
+
+import pandas as pd
+import zipcodes
+
 from selenium import webdriver
 from selenium.webdriver.common.keys import Keys
 from selenium.webdriver.chrome.options import DesiredCapabilities
 from selenium.webdriver.common.proxy import Proxy, ProxyType
-import pandas as pd
 from selenium.webdriver.common.by import By
-import json
-import random
-import os
 
 # maeve andersen
 # 27 august 2023
@@ -87,10 +90,10 @@ with open("proxy_list.csv", "r", encoding="utf-8") as proxy_csv:
     for row in reader:
         proxy_list.append(row)
 
-# my laziness knows no bounds
-zip_codes = [ str(i).zfill(5) for i in range(00501, 99951) ]
+# scan possible zip codes for validity before checking their chapter assignment
+zip_codes = [ valid_zip for i in range(501, 99951) if zipcodes.is_real(valid_zip := str(i).zfill(5)) ]
 
-# webdriver
+# initialize webdriver
 driver = webdriver.Chrome()
 
 # create the .csv

--- a/scraper/scraper.py
+++ b/scraper/scraper.py
@@ -89,7 +89,7 @@ with open("proxy_list.csv", "r", encoding="utf-8") as proxy_csv:
         proxy_list.append(row)
 
 # scan possible zip codes for validity before checking their chapter assignment
-zip_codes = [ valid_zip for i in range(501, 99951) if zipcodes.is_real(valid_zip := str(i).zfill(5)) ]
+ZIP_CODES = [zip_data["zip_code"] for zip_data in zipcodes.list_all()]
 
 # initialize webdriver
 driver = webdriver.Chrome()
@@ -101,7 +101,7 @@ with open("chapter_zips.csv", "w", newline="") as csvfile:
     
     writer.writeheader()
 
-    for zip_code in zip_codes:
+    for zip_code in ZIP_CODES:
         print(zip_code)
         proxy = get_random_proxy(proxy_list)
         zip_code, chapter_name = scrape_zip_code(zip_code, driver, proxy)

--- a/scraper/scraper.py
+++ b/scraper/scraper.py
@@ -88,7 +88,7 @@ with open("proxy_list.csv", "r", encoding="utf-8") as proxy_csv:
     for row in reader:
         proxy_list.append(row)
 
-# scan possible zip codes for validity before checking their chapter assignment
+# assemble list of zip codes to scrape
 ZIP_CODES = [zip_data["zip_code"] for zip_data in zipcodes.list_all()]
 
 # initialize webdriver


### PR DESCRIPTION
This reduces the run time dramatically by cutting API calls from 99,450(+retries) to 42,724(+retries). That's approximately a 57% reduction in API calls and is much kinder to the server hosting that API.

I did a bunch of further stuff at MaineDSA/dsa_chapter_zip_codes, but this seemed important to offer back upstream since it will save the server hosting that API a lot of grief.